### PR TITLE
Migrate to msgspec

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,9 @@
 exceptiongroup==1.1.1
 iniconfig==2.0.0
+msgspec==0.15.1
 packaging==23.1
 pluggy==1.0.0
-pydantic==1.10.8
+pydantic==1.10.9
 pytest==7.3.1
 pytest-asyncio==0.21.0
 tomli==2.0.1

--- a/renats/client/client.py
+++ b/renats/client/client.py
@@ -3,6 +3,8 @@ import logging
 from asyncio import Task
 from typing import Final
 
+import msgspec.json
+
 from .types import Server
 from ..connection.base import BaseConnection
 from ..connection.tcp import TcpConnection
@@ -61,7 +63,10 @@ class NatsClient:
         await self.send_raw(protocol_message.dump())
 
     async def _process_connection_init(self):
-        info = InfoProtocolMessage.parse_raw((await self.connection.readline()).split(b" ", 1)[1].decode())
+        info = msgspec.json.decode(
+            (await self.connection.readline()).split(b" ", 1)[1].decode(),
+            type=InfoProtocolMessage
+        )
         self.logger.info(f"Received INFO: {info}")
         self._server = Server(
             id=info.server_id,

--- a/renats/connection/tcp.py
+++ b/renats/connection/tcp.py
@@ -1,6 +1,5 @@
 import asyncio
 from asyncio import StreamReader, StreamWriter
-from typing import Final
 
 from .base import BaseConnection
 

--- a/renats/protocol/messages/msg.py
+++ b/renats/protocol/messages/msg.py
@@ -1,50 +1,20 @@
 import re
 
-from pydantic import validator, BaseModel
+from msgspec import Struct
 
 MSG_HEAD_PATTERN = re.compile(br"^MSG\s+(\S+)\s+(\S+)\s+((\S+)\s+)?(\d+)")
 
 
-class MsgProtocolMessage(BaseModel):
-    subject: str
-    sid: str
+class MsgProtocolMessage(Struct):
     reply_to: str | None = None
-    payload_length: int
     payload: bytes | None = None
 
-    @validator("payload")
-    def check_payload(cls, v, values):
-        if len(v) != values.get("payload_length"):
-            raise ValueError("Payload length must be equal to payload_length parameter")
-        return v
 
-    @validator("subject")
-    def check_subject(cls, v):
-        if len(v) == 0:
-            raise ValueError("Subject can't be empty string")
-        if " " in v:
-            raise ValueError("Subject can't contain whitespaces")
-        return v
-
-    @validator("reply_to")
-    def check_reply_to(cls, v):
-        if v is None:
-            return v
-        if len(v) == 0:
-            raise ValueError("Reply to can't be empty string, use None instead")
-        if " " in v:
-            raise ValueError("Reply to can't contain whitespaces")
-        return v
-
-    @validator("sid")
-    def check_sid(cls, v):
-        if len(v) == 0:
-            raise ValueError("Sid can't be empty string")
-        if " " in v:
-            raise ValueError("Sid can't contain whitespaces")
-        return v
-
-
-class HMsgProtocolMessage(MsgProtocolMessage):
+class HMsgProtocolMessage(Struct):
+    subject: str
+    sid: str
+    payload_length: int
     headers_length: int
     headers: dict[str, str]
+    reply_to: str | None = None
+    payload: bytes | None = None

--- a/renats/protocol/messages/pub.py
+++ b/renats/protocol/messages/pub.py
@@ -1,34 +1,16 @@
-from pydantic import validator, BaseModel
+from msgspec import Struct
 
-from .. import utils, protocol
 from .base import SerializableProtocolMessage
+from .. import utils, protocol
 
 
-class PubProtocolMessage(BaseModel, SerializableProtocolMessage):
+class PubProtocolMessage(Struct, SerializableProtocolMessage):
     """
     NATS protocol message model for PUB message
     """
     subject: str
     reply_to: str | None = None
     payload: bytes = b""
-
-    @validator("subject")
-    def check_subject(cls, v):
-        if len(v) == 0:
-            raise ValueError("Subject can't be empty string")
-        if " " in v:
-            raise ValueError("Subject can't contain whitespaces")
-        return v
-
-    @validator("reply_to")
-    def check_reply_to(cls, v):
-        if v is None:
-            return v
-        if len(v) == 0:
-            raise ValueError("Reply to can't be empty string, use None instead")
-        if " " in v:
-            raise ValueError("Reply to can't contain whitespaces")
-        return v
 
     def dump(self) -> bytes:
         """
@@ -44,18 +26,14 @@ class PubProtocolMessage(BaseModel, SerializableProtocolMessage):
         return head + utils.CRLF + self.payload + utils.CRLF
 
 
-class HPubProtocolMessage(PubProtocolMessage):
+class HPubProtocolMessage(Struct, SerializableProtocolMessage):
     """
     NATS protocol message model for HPUB message
     """
+    subject: str
     headers: dict[str, str]
-
-    @validator("headers")
-    def check_headers(cls, v):
-        for key in v:
-            if key.strip() != key:
-                raise ValueError("Header keys must be stripped")
-        return v
+    reply_to: str | None = None
+    payload: bytes = b""
 
     def dump(self) -> bytes:
         """

--- a/renats/protocol/messages/service.py
+++ b/renats/protocol/messages/service.py
@@ -1,13 +1,14 @@
 import re
 
-from pydantic import BaseModel, Field
+import msgspec.json
+from msgspec import Struct, field
 
 from .base import SerializableProtocolMessage
 
 INFO_HEAD_PATTERN = re.compile(br"^INFO\s+(.+)\r\n$")
 
 
-class InfoProtocolMessage(BaseModel):
+class InfoProtocolMessage(Struct):
     """
     NATS protocol message model for INFO message
     """
@@ -37,19 +38,19 @@ class InfoProtocolMessage(BaseModel):
     domain: str | None = None
 
 
-class ConnectProtocolMessage(BaseModel, SerializableProtocolMessage):
+class ConnectProtocolMessage(Struct, SerializableProtocolMessage, omit_defaults=True):
     """
     NATS protocol message model for CONNECT message
     """
     verbose: bool
     pedantic: bool
     tls_required: bool
-    auth_token: str | None = None
-    user: str | None = None
-    password: str | None = Field(None, alias="pass")
-    name: str | None = None
     lang: str
     version: str
+    auth_token: str | None = None
+    user: str | None = None
+    password: str | None = field(name="pass")
+    name: str | None = None
     protocol: int | None = None
     echo: bool | None = None
     sig: str | None = None
@@ -63,10 +64,10 @@ class ConnectProtocolMessage(BaseModel, SerializableProtocolMessage):
         Dump NATS protocol CONNECT message to bytes
         :return: NATS protocol CONNECT message as bytes-encoded string
         """
-        return f"CONNECT {self.json(skip_defaults=True)}\r\n".encode()
+        return f"CONNECT {msgspec.json.encode(self)}\r\n".encode()
 
 
-class ErrProtocolMessage(BaseModel):
+class ErrProtocolMessage(Struct):
     """
     NATS protocol message model for ERR message
     """

--- a/renats/protocol/messages/sub.py
+++ b/renats/protocol/messages/sub.py
@@ -1,42 +1,16 @@
-from pydantic import validator, BaseModel
+from msgspec import Struct
 
-from .. import utils, protocol
 from .base import SerializableProtocolMessage
+from .. import utils, protocol
 
 
-class SubProtocolMessage(BaseModel, SerializableProtocolMessage):
+class SubProtocolMessage(Struct, SerializableProtocolMessage):
     """
     NATS protocol message model for SUB message
     """
     subject: str
-    queue_group: str | None = None
     sid: str
-
-    @validator("subject")
-    def check_subject(cls, v):
-        if " " in v:
-            raise ValueError("Subject can't contain whitespaces")
-        if len(v) == 0:
-            raise ValueError("Queue group can't be empty string")
-        return v
-
-    @validator("queue_group")
-    def check_queue_group(cls, v):
-        if v is None:
-            return v
-        if len(v) == 0:
-            raise ValueError("Queue group can't be empty string, use None instead")
-        if " " in v:
-            raise ValueError("Queue group can't contain whitespaces")
-        return v
-
-    @validator("sid")
-    def check_sid(cls, v):
-        if len(v) == 0:
-            raise ValueError("Sid can't be empty string")
-        if " " in v:
-            raise ValueError("Sid can't contain whitespaces")
-        return v
+    queue_group: str | None = None
 
     def dump(self) -> bytes:
         """
@@ -52,20 +26,12 @@ class SubProtocolMessage(BaseModel, SerializableProtocolMessage):
         return head + utils.CRLF
 
 
-class UnsubProtocolMessage(BaseModel, SerializableProtocolMessage):
+class UnsubProtocolMessage(Struct, SerializableProtocolMessage):
     """
     NATS protocol message model for UNSUB message
     """
     sid: str
     max_msgs: int | None = None
-
-    @validator("sid")
-    def check_sid(cls, v):
-        if len(v) == 0:
-            raise ValueError("Sid can't be empty string")
-        if " " in v:
-            raise ValueError("Sid can't contain whitespaces")
-        return v
 
     def dump(self) -> bytes:
         """


### PR DESCRIPTION
Migrated all protocol message models and their serialization to `msgspec` library for performance reasons. 
Previously, `pydantic` was used, but switching to `msgspec` can greatly improve performance in the moments of validation, serialization and deserialization of models.